### PR TITLE
Lits d’arène non-interactifs (silencieux) + compat setbed — 1.1.8

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: HikaBrain
 main: com.example.hikabrain.HikaBrainPlugin
-version: 1.1.7
+version: 1.1.8
 api-version: 1.1.6
 description: Hikabrain mini-game for Spigot 1.21 (world-restricted)
 


### PR DESCRIPTION
## Summary
- Bloque silencieusement toute interaction avec les lits, tout en conservant la sélection admin /hb setbed.
- Empêche le sommeil sur les lits d’arène et protège leur casse sans outil dédié.
- Mise à jour de la version du plugin en 1.1.8.

## Testing
- `gradle build`

------
https://chatgpt.com/codex/tasks/task_e_689a47226ac88324a8537858afdefccb