### PR TITLE
Scoreboard adaptatif (zéro espace vide) + bump versions Gradle/plugin (1.2.3)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,8 +2,8 @@ plugins {
     java
 }
 
-group = "com.hikabrain"
-version = "1.1.9.1"
+group = "com.example"
+version = "1.2.3"
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/example/hikabrain/GameManager.java
+++ b/src/main/java/com/example/hikabrain/GameManager.java
@@ -120,7 +120,7 @@ public class GameManager {
         arena.players().get(t).add(p.getUniqueId());
         p.sendMessage((t==Team.RED?ChatColor.RED:ChatColor.BLUE) + "Tu rejoins " + t.name());
         plugin.scoreboard().show(p, arena);
-        plugin.scoreboard().update(arena);
+        plugin.scoreboard().updatePlayers(arena);
         plugin.tablist().update(arena);
     }
 
@@ -129,7 +129,7 @@ public class GameManager {
         for (Set<UUID> s : arena.players().values()) s.remove(p.getUniqueId());
         plugin.scoreboard().hide(p);
         plugin.tablist().remove(p);
-        plugin.scoreboard().update(arena);
+        plugin.scoreboard().updatePlayers(arena);
         plugin.tablist().update(arena);
         p.sendMessage(ChatColor.GRAY + "Tu as quitté la partie.");
     }
@@ -365,7 +365,7 @@ public class GameManager {
         if (arena == null || !arena.isActive()) return;
         if (isFrozen()) return;
         if (t == Team.RED) arena.redScore(arena.redScore()+1); else if (t == Team.BLUE) arena.blueScore(arena.blueScore()+1);
-        plugin.scoreboard().update(arena);
+        plugin.scoreboard().updateScore(arena);
         plugin.tablist().update(arena);
         plugin.fx().playTeamPreset(t, Presets.SCORE_BED);
 

--- a/src/main/java/com/example/hikabrain/HikaScoreboard.java
+++ b/src/main/java/com/example/hikabrain/HikaScoreboard.java
@@ -5,6 +5,9 @@ import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.scoreboard.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Player scoreboard used by ScoreboardService. Lines are pooled
  * and updated via teams to avoid flicker.
@@ -18,6 +21,17 @@ public class HikaScoreboard {
             "§0", "§1", "§2", "§3", "§4", "§5", "§6", "§7",
             "§8", "§9", "§a", "§b", "§c", "§d", "§e"
     };
+    private final List<LineType> structure = new ArrayList<>();
+    private String cachedSeparator = "";
+    private int cachedSepWidth = -1;
+
+    private enum LineType { MAP, MODE, TIME, SCORE, STREAK, PLAYERS, SEPARATOR, HELP, DOMAIN }
+
+    private static class Line {
+        final LineType type;
+        final String text;
+        Line(LineType type, String text) { this.type = type; this.text = text; }
+    }
 
     public HikaScoreboard(HikaBrainPlugin plugin) {
         this.plugin = plugin;
@@ -35,7 +49,6 @@ public class HikaScoreboard {
             lines[i] = board.getTeam("l" + i);
             if (lines[i] == null) lines[i] = board.registerNewTeam("l" + i);
             lines[i].addEntry(ENTRIES[i]);
-            obj.getScore(ENTRIES[i]).setScore(15 - i);
         }
     }
 
@@ -47,21 +60,74 @@ public class HikaScoreboard {
 
     public void update(Arena arena, Player p, int timeRemaining) {
         if (arena == null) return;
-        String mmss = String.format("%02d:%02d", Math.max(0, timeRemaining) / 60, Math.max(0, timeRemaining) % 60);
+        List<Line> built = buildLines(arena, timeRemaining);
+        boolean needRebuild = structure.size() != built.size();
+        if (!needRebuild) {
+            for (int i = 0; i < built.size(); i++) {
+                if (structure.get(i) != built.get(i).type) { needRebuild = true; break; }
+            }
+        }
+        if (needRebuild) {
+            rebuild();
+            structure.clear();
+            for (Line l : built) structure.add(l.type);
+            int n = built.size();
+            for (int i = 0; i < n; i++) obj.getScore(ENTRIES[i]).setScore(n - i);
+            for (int i = n; i < 15; i++) board.resetScores(ENTRIES[i]);
+        }
+        int n = built.size();
+        for (int i = 0; i < n; i++) {
+            lines[i].setPrefix(built.get(i).text);
+        }
+        for (int i = n; i < 15; i++) {
+            lines[i].setPrefix("");
+        }
+    }
+
+    private List<Line> buildLines(Arena arena, int timeRemaining) {
+        List<Line> L = new ArrayList<>();
+        if (arena != null && arena.name() != null)
+            L.add(new Line(LineType.MAP, ChatColor.GRAY + "Map: " + ChatColor.WHITE + arena.name()));
         int teamSize = plugin.game().teamSize();
-        int capacity = teamSize * 2;
-        int inArena = plugin.game().playersInArena(arena);
-        String mode = teamSize + "v" + teamSize;
-        lines[0].setPrefix(ChatColor.GRAY + "Map: " + ChatColor.WHITE + arena.name());
-        lines[1].setPrefix(ChatColor.GRAY + "Mode: " + ChatColor.WHITE + mode);
-        lines[2].setPrefix(ChatColor.GRAY + "Temps: " + ChatColor.WHITE + mmss);
-        lines[3].setPrefix(ChatColor.RED + "Rouge: " + ChatColor.WHITE + arena.redScore() + "  " +
-                ChatColor.BLUE + "Bleu: " + ChatColor.WHITE + arena.blueScore());
-        lines[4].setPrefix(ChatColor.GRAY + "Série: " + ChatColor.WHITE + "0");
-        lines[5].setPrefix(ChatColor.GRAY + "Joueurs: " + ChatColor.WHITE + inArena + "/" + capacity);
-        lines[6].setPrefix(plugin.style().separator());
-        lines[7].setPrefix(ChatColor.GRAY + "/hb help");
-        lines[8].setPrefix(ChatColor.DARK_GRAY + plugin.style().domain());
-        for (int i = 9; i < 15; i++) lines[i].setPrefix("");
+        if (teamSize > 0)
+            L.add(new Line(LineType.MODE, ChatColor.GRAY + "Mode: " + ChatColor.WHITE + teamSize + "v" + teamSize));
+        String mmss = String.format("%02d:%02d", Math.max(0, timeRemaining) / 60, Math.max(0, timeRemaining) % 60);
+        L.add(new Line(LineType.TIME, ChatColor.GRAY + "Temps: " + ChatColor.WHITE + mmss));
+        L.add(new Line(LineType.SCORE,
+                ChatColor.RED + "Rouge: " + ChatColor.WHITE + arena.redScore() + "  " +
+                        ChatColor.BLUE + "Bleu: " + ChatColor.WHITE + arena.blueScore()));
+        int streak = 0; // placeholder streak
+        if (streak > 0)
+            L.add(new Line(LineType.STREAK, ChatColor.GRAY + "Série: " + ChatColor.WHITE + streak));
+        if (arena != null) {
+            int capacity = teamSize * 2;
+            int inArena = plugin.game().playersInArena(arena);
+            L.add(new Line(LineType.PLAYERS,
+                    ChatColor.GRAY + "Joueurs: " + ChatColor.WHITE + inArena + "/" + capacity));
+        }
+        int max = 12;
+        for (Line l : L) max = Math.max(max, visualWidth(l.text));
+        L.add(new Line(LineType.SEPARATOR, separator(max)));
+        L.add(new Line(LineType.HELP, ChatColor.GRAY + "/hb help"));
+        L.add(new Line(LineType.DOMAIN, ChatColor.DARK_GRAY + plugin.style().domain()));
+        return L;
+    }
+
+    private static int visualWidth(String s) {
+        int w = 0; boolean skip = false;
+        for (char c : s.toCharArray()) {
+            if (skip) { skip = false; continue; }
+            if (c == '§') { skip = true; continue; }
+            w++;
+        }
+        return w;
+    }
+
+    private String separator(int width) {
+        if (width == cachedSepWidth) return cachedSeparator;
+        int w = Math.max(1, Math.min(width, 20));
+        cachedSepWidth = width;
+        cachedSeparator = ChatColor.DARK_GRAY + "" + "\u2500".repeat(w);
+        return cachedSeparator;
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: HikaBrain
 main: com.example.hikabrain.HikaBrainPlugin
-version: 1.2.1
+version: 1.2.3
 api-version: 1.1.6
 description: Hikabrain mini-game for Spigot 1.21 (world-restricted)
 


### PR DESCRIPTION
## Summary
- Refactor HikaScoreboard to build dynamic lines without empty slots, rebuild objective only when structure changes and generate a width-aware separator.
- Update GameManager to trigger event-driven scoreboard refreshes for player joins, leaves and scoring.
- Bump project and plugin versions to 1.2.3.

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_689b7c930d08832480420e44f7672b17