### PR TITLE
feat: support world_hika

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = "com.example"
-version = "1.2.6"
+version = "1.2.7"
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/example/hikabrain/Arena.java
+++ b/src/main/java/com/example/hikabrain/Arena.java
@@ -79,6 +79,11 @@ public class Arena {
         if (name == null) throw new IOException("Missing arena name");
         Arena a = new Arena(name);
         a.worldName = cfg.getString("world");
+        if ("hika".equalsIgnoreCase(a.worldName)) {
+            a.worldName = "world_hika";
+            cfg.set("world", "world_hika");
+            cfg.save(file);
+        }
         a.spawnRed = loadLoc(cfg, "spawn.red");
         a.spawnBlue = loadLoc(cfg, "spawn.blue");
         a.bedRed = loadLoc(cfg, "bed.red");

--- a/src/main/java/com/example/hikabrain/ui/compass/CompassGuiService.java
+++ b/src/main/java/com/example/hikabrain/ui/compass/CompassGuiService.java
@@ -40,6 +40,7 @@ public class CompassGuiService {
 
     /** Open the main mode selection menu. */
     public void openModeMenu(Player p) {
+        if (!plugin.isWorldAllowed(p.getWorld())) return;
         Inventory inv = Bukkit.createInventory(holder, 54, ChatColor.AQUA + "Choix du mode");
         addMode(inv, 10, 1);
         addMode(inv, 12, 2);
@@ -51,6 +52,7 @@ public class CompassGuiService {
 
     /** Open arena list for given team size. */
     public void openArenaList(Player p, int teamSize) {
+        if (!plugin.isWorldAllowed(p.getWorld())) return;
         Inventory inv = Bukkit.createInventory(holder, 54,
                 ChatColor.AQUA + "Arènes " + ChatColor.GRAY + "(" + ChatColor.WHITE + teamSize + "v" + teamSize + ChatColor.GRAY + ")");
         int slot = 10;

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: HikaBrain
 main: com.example.hikabrain.HikaBrainPlugin
-version: 1.2.6
+version: 1.2.7
 api-version: 1.1.6
 description: Hikabrain mini-game for Spigot 1.21 (world-restricted)
 


### PR DESCRIPTION
## Summary
- migrate legacy "hika" world references to `world_hika`
- allow lobby compass and admin features only in configured worlds
- bump plugin version to 1.2.7

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_689bc38e6ec88324a17da8b6cd8191ca