### PR TITLE
Boussole (air/noTP), GUI verrouillé, join anti-spam/atomique, édition d’arène (casser lits) — 1.2.8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = "com.example"
-version = "1.2.7"
+version = "1.2.8"
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/example/hikabrain/AdminModeService.java
+++ b/src/main/java/com/example/hikabrain/AdminModeService.java
@@ -1,0 +1,28 @@
+package com.example.hikabrain;
+
+import org.bukkit.entity.Player;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** Tracks players with temporary admin editing rights. */
+public class AdminModeService {
+    private final Set<UUID> enabled = ConcurrentHashMap.newKeySet();
+
+    /** Enable admin mode for given player. */
+    public void enable(Player p) { enabled.add(p.getUniqueId()); }
+
+    /** Disable admin mode for given player. */
+    public void disable(Player p) { enabled.remove(p.getUniqueId()); }
+
+    /** Toggle admin mode and return new state. */
+    public boolean toggle(Player p) {
+        UUID id = p.getUniqueId();
+        if (enabled.contains(id)) { enabled.remove(id); return false; }
+        enabled.add(id); return true;
+    }
+
+    /** Check if player currently has admin mode enabled. */
+    public boolean isEnabled(Player p) { return enabled.contains(p.getUniqueId()); }
+}

--- a/src/main/java/com/example/hikabrain/HBCommand.java
+++ b/src/main/java/com/example/hikabrain/HBCommand.java
@@ -11,6 +11,7 @@ import org.bukkit.entity.Player;
 import com.example.hikabrain.ui.FeedbackServiceImpl;
 import com.example.hikabrain.ui.ThemeServiceImpl;
 import com.example.hikabrain.ui.UiServiceImpl;
+import com.example.hikabrain.AdminModeService;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -34,6 +35,7 @@ public class HBCommand implements CommandExecutor, TabCompleter {
         s.sendMessage(ChatColor.YELLOW + "/hb leave" + ChatColor.GRAY + " - Quitter la partie");
         s.sendMessage(ChatColor.YELLOW + "/hb ui reload" + ChatColor.GRAY + " - Recharge la configuration UI");
         s.sendMessage(ChatColor.YELLOW + "/hb theme <id>" + ChatColor.GRAY + " - Applique un thème");
+        s.sendMessage(ChatColor.YELLOW + "/hb admin [on|off|toggle]" + ChatColor.GRAY + " - Mode édition arène");
         s.sendMessage(ChatColor.DARK_GRAY + "Admin: create, setspawn, setbuildpos, setpoints, settimer, setlobby, save, load, start, stop");
     }
 
@@ -92,6 +94,21 @@ public class HBCommand implements CommandExecutor, TabCompleter {
                 if (needAdmin(sender)) return true;
                 game.resetBroke();
                 sender.sendMessage(ChatColor.GREEN + "Reset broke lancé.");
+                return true;
+            }
+            case "admin": {
+                if (needAdmin(sender)) return true;
+                if (!(sender instanceof Player)) { sender.sendMessage("In-game only"); return true; }
+                Player p = (Player) sender;
+                String arg = args.length >= 2 ? args[1].toLowerCase() : "toggle";
+                AdminModeService am = HikaBrainPlugin.get().admin();
+                boolean enabled;
+                switch (arg) {
+                    case "on": am.enable(p); enabled = true; break;
+                    case "off": am.disable(p); enabled = false; break;
+                    default: enabled = am.toggle(p); break;
+                }
+                sender.sendMessage(ChatColor.YELLOW + "Admin: " + (enabled ? ChatColor.GREEN + "ON" : ChatColor.RED + "OFF"));
                 return true;
             }
             case "ui": {
@@ -221,7 +238,7 @@ case "join": {
 
     @Override
     public List<String> onTabComplete(CommandSender sender, org.bukkit.command.Command command, String alias, String[] args) {
-        if (args.length == 1) return Arrays.asList("help","list","setbed","join","leave","create","setspawn","setbuildpos","setpoints","settimer","save","load","start","stop","setbroke","snapshotbroke","resetbroke","ui","theme","setlobby");
+        if (args.length == 1) return Arrays.asList("help","list","setbed","join","leave","create","setspawn","setbuildpos","setpoints","settimer","save","load","start","stop","setbroke","snapshotbroke","resetbroke","ui","theme","setlobby","admin");
         if (args.length == 2) {
             switch (args[0].toLowerCase()) {
                 case "setspawn": return Arrays.asList("red","blue");
@@ -231,6 +248,7 @@ case "join": {
                 case "join": return Arrays.asList("red","blue");
                 case "ui": return Arrays.asList("reload");
                 case "theme": return new ArrayList<>(HikaBrainPlugin.get().theme().available());
+                case "admin": return Arrays.asList("on","off","toggle");
             }
         }
         if (args.length == 3 && args[0].equalsIgnoreCase("create")) {

--- a/src/main/java/com/example/hikabrain/HikaBrainPlugin.java
+++ b/src/main/java/com/example/hikabrain/HikaBrainPlugin.java
@@ -42,6 +42,7 @@ public class HikaBrainPlugin extends JavaPlugin {
     private CompassGuiService compassGui;
     private LobbyService lobbyService;
     private ArenaRegistry arenaRegistry;
+    private AdminModeService adminMode;
     private UiStyle uiStyle;
     private String serverDisplayName;
     private String serverDomain;
@@ -67,9 +68,10 @@ public class HikaBrainPlugin extends JavaPlugin {
         this.compassGui = new CompassGuiService(this);
         this.lobbyService = new LobbyService(this);
         this.arenaRegistry = new ArenaRegistry(this);
+        this.adminMode = new AdminModeService();
 
         this.gameManager = new GameManager(this);
-        getServer().getPluginManager().registerEvents(new GameListener(gameManager), this);
+        getServer().getPluginManager().registerEvents(new GameListener(gameManager, adminMode), this);
 
         boolean registered = false;
         try {
@@ -158,6 +160,7 @@ public class HikaBrainPlugin extends JavaPlugin {
     public CompassGuiService compassGui() { return compassGui; }
     public LobbyService lobbyService() { return lobbyService; }
     public ArenaRegistry arenaRegistry() { return arenaRegistry; }
+    public AdminModeService admin() { return adminMode; }
     public UiStyle style() { return uiStyle; }
     public String serverDisplayName() { return serverDisplayName; }
     public String serverDomain() { return serverDomain; }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: HikaBrain
 main: com.example.hikabrain.HikaBrainPlugin
-version: 1.2.7
+version: 1.2.8
 api-version: 1.1.6
 description: Hikabrain mini-game for Spigot 1.21 (world-restricted)
 


### PR DESCRIPTION
## Summary
- Remplace le cooldown de la boussole par un flag metadata pour bloquer toute téléportation pendant 5 ticks et ouvre le menu même en l’air
- Ajoute le mode admin permettant de casser/poser partout et de configurer les arènes, avec la commande `/hb admin`
- Verrouille totalement l’UI de la boussole et durcit le join via anti-spam et section critique atomique
- Bump de la version du plugin en 1.2.8

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_689bc8ea41448324bda65691a777cc3b