### PR TITLE
Bundle Kyori Adventure dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     java
+    id("com.github.johnrengelman.shadow") version "8.1.1"
 }
 
 group = "com.example"
@@ -13,8 +14,8 @@ repositories {
 
 dependencies {
     compileOnly("org.spigotmc:spigot-api:1.21-R0.1-SNAPSHOT")
-    compileOnly("net.kyori:adventure-api:4.17.0")
-    compileOnly("net.kyori:adventure-text-serializer-legacy:4.17.0")
+    implementation("net.kyori:adventure-api:4.17.0")
+    implementation("net.kyori:adventure-text-serializer-legacy:4.17.0")
     testImplementation("junit:junit:4.13.2")
 }
 
@@ -27,4 +28,8 @@ java {
 tasks.withType<org.gradle.api.tasks.compile.JavaCompile>().configureEach {
     options.encoding = "UTF-8"
     options.release.set(21)
+}
+
+tasks.build {
+    dependsOn(tasks.shadowJar)
 }


### PR DESCRIPTION
## Summary
- bundle Kyori Adventure API and serializer using shadowJar
- ensure plugin build produces fat jar for Spigot servers

## Testing
- `gradle build`
- `jar tf build/libs/HikaBrain-1.2.11-all.jar | rg kyori | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_689c6a0f178483248785ca077014ebf1