### PR TITLE
Fix lobby compass interaction and drop restrictions

### DIFF
--- a/src/main/java/com/example/hikabrain/GameListener.java
+++ b/src/main/java/com/example/hikabrain/GameListener.java
@@ -296,7 +296,7 @@ public class GameListener implements Listener {
     @EventHandler
     public void onCompassDrop(PlayerDropItemEvent e) {
         Player p = e.getPlayer();
-        if (admin.isEnabled(p)) return;
+        if (p.isOp() || admin.isEnabled(p)) return;
         if (game.arena() != null && game.arena().isActive()) return;
         if (isLobbyCompass(e.getItemDrop().getItemStack()) && isAllowedWorld(p.getWorld())) {
             e.setCancelled(true);
@@ -363,6 +363,8 @@ public class GameListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onCompassInteract(PlayerInteractEvent e) {
+        Action action = e.getAction();
+        if (action != Action.RIGHT_CLICK_AIR && action != Action.RIGHT_CLICK_BLOCK) return;
         if (e.getHand() != EquipmentSlot.HAND) return;
         Player p = e.getPlayer();
         if (!isAllowedWorld(p.getWorld())) return;


### PR DESCRIPTION
## Summary
- Open arena selector compass when clicking air
- Allow OPs to drop items and only block dropping the lobby compass

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_689c6ddfc0748324904b6ce4208ca7a5