### PR TITLE
feat: finalize lobby clock experience

### DIFF
--- a/src/main/java/com/example/hikabrain/GameListener.java
+++ b/src/main/java/com/example/hikabrain/GameListener.java
@@ -296,8 +296,18 @@ public class GameListener implements Listener {
     @EventHandler
     public void onCompassDrop(PlayerDropItemEvent e) {
         Player p = e.getPlayer();
-        if (p.isOp() || admin.isEnabled(p)) return;
-        if (game.arena() != null && game.arena().isActive()) return;
+
+        // Operators or players in admin mode can drop anything.
+        if (p.isOp() || admin.isEnabled(p)) {
+            return;
+        }
+
+        // During an active game, drop behaviour is handled elsewhere.
+        if (game.arena() != null && game.arena().isActive()) {
+            return;
+        }
+
+        // Only block dropping the lobby item in allowed worlds.
         if (isLobbyCompass(e.getItemDrop().getItemStack()) && isAllowedWorld(p.getWorld())) {
             e.setCancelled(true);
         }
@@ -361,16 +371,17 @@ public class GameListener implements Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    @EventHandler(priority = EventPriority.HIGHEST)
     public void onCompassInteract(PlayerInteractEvent e) {
         Action action = e.getAction();
-        if (action != Action.RIGHT_CLICK_AIR && action != Action.RIGHT_CLICK_BLOCK) return;
+        if (action != Action.RIGHT_CLICK_AIR && action != Action.RIGHT_CLICK_BLOCK) {
+            return;
+        }
         if (e.getHand() != EquipmentSlot.HAND) return;
         Player p = e.getPlayer();
         if (!isAllowedWorld(p.getWorld())) return;
         if (!isLobbyCompass(e.getItem())) return;
-        e.setUseItemInHand(Event.Result.DENY);
-        e.setUseInteractedBlock(Event.Result.DENY);
+        // Cancel to prevent default item behaviour (e.g. compass sound).
         e.setCancelled(true);
         HikaBrainPlugin.get().compassGui().openModeMenu(p);
         long tick = System.currentTimeMillis();

--- a/src/main/java/com/example/hikabrain/lobby/LobbyService.java
+++ b/src/main/java/com/example/hikabrain/lobby/LobbyService.java
@@ -32,10 +32,11 @@ public class LobbyService {
         }
     }
 
-    /** Give the navigation compass and clear inventory. */
-    public void giveCompass(Player p) {
+    /** Give the lobby selector item and clear inventory. */
+    public void giveLobbyItem(Player p) {
         p.getInventory().clear();
-        ItemStack it = new ItemStack(Material.RECOVERY_COMPASS);
+        // Use a clock as lobby selector instead of the recovery compass.
+        ItemStack it = new ItemStack(Material.CLOCK);
         ItemMeta meta = it.getItemMeta();
         if (meta != null) {
             try {
@@ -51,10 +52,10 @@ public class LobbyService {
         p.getInventory().setItem(4, it);
     }
 
-    /** Apply full lobby profile: teleport, compass, scoreboard and tablist. */
+    /** Apply full lobby profile: teleport, lobby item, scoreboard and tablist. */
     public void apply(Player p) {
         teleport(p);
-        giveCompass(p);
+        giveLobbyItem(p);
         plugin.scoreboard().showLobby(p);
         plugin.tablist().showLobby(p);
     }


### PR DESCRIPTION
## Summary
- Replace lobby recovery compass with a clock and rename helper to giveLobbyItem
- Allow lobby menu to open when right-clicking air or blocks
- Restrict dropping of lobby item while permitting other drops unless op/admin

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_689c733949d88324b52d4261dd797e17