### PR TITLE
feat: improve game start and arena selection UI

### DIFF
--- a/src/main/java/com/example/hikabrain/ui/UiService.java
+++ b/src/main/java/com/example/hikabrain/ui/UiService.java
@@ -4,11 +4,14 @@ import com.example.hikabrain.Arena;
 import com.example.hikabrain.GamePhase;
 import net.kyori.adventure.text.Component;
 import org.bukkit.entity.Player;
+import org.bukkit.Sound;
 
 public interface UiService {
     void pushActionbar(Player p, Component c, int ttlTicks);
     void setBossPhase(GamePhase phase, float progress);
     void showIntroCountdown(Arena a, int seconds);
+    void broadcastTitle(Arena a, String title, String subtitle, int fadeIn, int stay, int fadeOut);
+    void broadcastSound(Arena a, Sound sound, float volume, float pitch);
     void updateSidebar(Arena a);
     void clearAll(Arena a);
 }

--- a/src/main/java/com/example/hikabrain/ui/UiServiceImpl.java
+++ b/src/main/java/com/example/hikabrain/ui/UiServiceImpl.java
@@ -7,6 +7,7 @@ import com.example.hikabrain.Team;
 import com.example.hikabrain.ui.model.Presets;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.Sound;
 import org.bukkit.boss.BarColor;
 import org.bukkit.boss.BarStyle;
 import org.bukkit.boss.BossBar;
@@ -131,6 +132,40 @@ public class UiServiceImpl implements UiService {
                 c--;
             }
         }.runTaskTimer(plugin, 0L, 20L);
+    }
+
+    @Override
+    public void broadcastTitle(Arena a, String title, String subtitle, int fadeIn, int stay, int fadeOut) {
+        if (a == null) return;
+        for (UUID u : a.players().getOrDefault(Team.RED, java.util.Collections.emptySet())) {
+            Player p = Bukkit.getPlayer(u);
+            if (p != null) p.sendTitle(title, subtitle, fadeIn, stay, fadeOut);
+        }
+        for (UUID u : a.players().getOrDefault(Team.BLUE, java.util.Collections.emptySet())) {
+            Player p = Bukkit.getPlayer(u);
+            if (p != null) p.sendTitle(title, subtitle, fadeIn, stay, fadeOut);
+        }
+        for (UUID u : a.players().getOrDefault(Team.SPECTATOR, java.util.Collections.emptySet())) {
+            Player p = Bukkit.getPlayer(u);
+            if (p != null) p.sendTitle(title, subtitle, fadeIn, stay, fadeOut);
+        }
+    }
+
+    @Override
+    public void broadcastSound(Arena a, Sound sound, float volume, float pitch) {
+        if (a == null) return;
+        for (UUID u : a.players().getOrDefault(Team.RED, java.util.Collections.emptySet())) {
+            Player p = Bukkit.getPlayer(u);
+            if (p != null) p.playSound(p.getLocation(), sound, volume, pitch);
+        }
+        for (UUID u : a.players().getOrDefault(Team.BLUE, java.util.Collections.emptySet())) {
+            Player p = Bukkit.getPlayer(u);
+            if (p != null) p.playSound(p.getLocation(), sound, volume, pitch);
+        }
+        for (UUID u : a.players().getOrDefault(Team.SPECTATOR, java.util.Collections.emptySet())) {
+            Player p = Bukkit.getPlayer(u);
+            if (p != null) p.playSound(p.getLocation(), sound, volume, pitch);
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary
- start game automatically when arena fills with 10 second countdown
- add UI broadcast helpers for titles and sounds
- revamp arena selection menu with dark glass filler and dynamic status info

## Testing
- `gradle test`

------
https://chatgpt.com/codex/tasks/task_e_689ce6b46cc88324a684017f3560cdb7