### PR TITLE
Enhance HikaBrain UX and game flow

### DIFF
--- a/src/main/java/com/example/hikabrain/GameListener.java
+++ b/src/main/java/com/example/hikabrain/GameListener.java
@@ -32,6 +32,7 @@ import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
@@ -364,6 +365,9 @@ public class GameListener implements Listener {
                 case "close":
                     p.closeInventory();
                     break;
+                case "leave":
+                    HikaBrainPlugin.get().game().leave(p);
+                    break;
             }
             return;
         }
@@ -387,6 +391,13 @@ public class GameListener implements Listener {
         if (isLobbyCompass(e.getOldCursor())) { e.setCancelled(true); return; }
         for (ItemStack it : e.getNewItems().values()) {
             if (isLobbyCompass(it)) { e.setCancelled(true); return; }
+        }
+    }
+
+    @EventHandler
+    public void onInventoryClose(InventoryCloseEvent e) {
+        if (e.getInventory().getHolder() instanceof com.example.hikabrain.ui.compass.CompassGuiService.Holder) {
+            HikaBrainPlugin.get().compassGui().cancelUpdateTask((Player) e.getPlayer());
         }
     }
 

--- a/src/main/java/com/example/hikabrain/commands/HBCommand.java
+++ b/src/main/java/com/example/hikabrain/commands/HBCommand.java
@@ -166,7 +166,12 @@ public class HBCommand implements CommandExecutor {
             }
             case "leave": {
                 if (!(sender instanceof Player)) { sender.sendMessage("In-game only"); return true; }
-                game.leave((Player) sender);
+                Player p = (Player) sender;
+                if (game.arena() == null || game.teamOf(p) == Team.SPECTATOR) {
+                    sender.sendMessage(ChatColor.RED + "Tu n'es pas en file.");
+                    return true;
+                }
+                game.leave(p);
                 return true;
             }
             case "create": {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -22,6 +22,9 @@ compass:
     rows: 6
     category_row: 1
 
+game:
+  start-countdown-seconds: 5
+
 debug: false
 
 server:


### PR DESCRIPTION
## Summary
- Refresh arena list every second and allow leaving the queue from GUI
- Redesign mode menu with themed icons and player counts
- Add configurable start countdown and auto-stop when players quit

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_689d9680e3a48324b7f9f559222075e8