### PR TITLE
feat: improve queue and game stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.3.1 - Queue & stability tweaks
+- **Feat:** Système de file repensé avec barrière de sortie.
+- **Fix:** Annulation du compte à rebours et arrêt de partie si un joueur quitte.
+- **UX:** Gel initial assoupli permettant de regarder autour de soi.
+
 ## 1.3.0 - Gameplay & UX Finalization
 - **Feat:** Replaced lobby navigation compass with a clock.
 - **Feat:** Implemented instant respawn in arenas, removing the death screen.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Java 21](https://img.shields.io/badge/Java-21-red?logo=openjdk)](https://openjdk.org/)
 [![Spigot/Paper 1.21](https://img.shields.io/badge/Spigot/Paper-1.21-yellow?logo=spigotmc)](https://www.spigotmc.org/)
 [![Gradle](https://img.shields.io/badge/Gradle-build-blue?logo=gradle)](https://gradle.org/)
-[![Version](https://img.shields.io/badge/Version-1.3.0-informational)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/Version-1.3.1-informational)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-MIT-green)](LICENSE)
 
 Site : [heneria.com](https://heneria.com)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.example"
-version = "1.3.0"
+version = "1.3.1"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
## Summary
- Replace lobby clock with tagged barrier for queue exit
- Cancel countdown and stop game when players quit early
- Allow camera rotation during start freeze and bump docs to 1.3.1

## Testing
- `gradle build`


------
https://chatgpt.com/codex/tasks/task_e_689d9e9797ac83248ce6c0c8a0f05408