### PR TITLE
[BUGFIX] Fix double selection message & block damage protection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.1 - Protection UX fixes
+- **Fix:** confirmation for "Position 2" is only sent once.
+- **Fix:** block hit animation is cancelled in protected zones.
+
 ## 1.4.0 - Protection de zones
 - **Feat:** Outil en jeu pour définir des zones protégées avec `/hb protect` et `/hb confirm`.
 - **Feat:** Chargement et sauvegarde persistants des régions protégées.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Java 21](https://img.shields.io/badge/Java-21-red?logo=openjdk)](https://openjdk.org/)
 [![Spigot/Paper 1.21](https://img.shields.io/badge/Spigot/Paper-1.21-yellow?logo=spigotmc)](https://www.spigotmc.org/)
 [![Gradle](https://img.shields.io/badge/Gradle-build-blue?logo=gradle)](https://gradle.org/)
-[![Version](https://img.shields.io/badge/Version-1.4.0-informational)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/Version-1.4.1-informational)](CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-MIT-green)](LICENSE)
 
 Site : [heneria.com](https://heneria.com)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.example"
-version = "1.4.0"
+version = "1.4.1"
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/example/hikabrain/GameListener.java
+++ b/src/main/java/com/example/hikabrain/GameListener.java
@@ -133,6 +133,9 @@ public class GameListener implements Listener {
 
     @EventHandler
     public void onProtectionToolInteract(PlayerInteractEvent e) {
+        if (e.getHand() != EquipmentSlot.HAND) {
+            return;
+        }
         Player player = e.getPlayer();
         if (!protectionService.isInProtectMode(player)) return;
         ItemStack tool = player.getInventory().getItemInMainHand();
@@ -340,6 +343,15 @@ public class GameListener implements Listener {
         if (protectionService.isProtected(e.getBlock().getLocation())) {
             e.setCancelled(true);
             player.sendMessage("§cVous ne pouvez pas construire ici.");
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onBlockDamageInProtectedZone(BlockDamageEvent e) {
+        Player player = e.getPlayer();
+        if (player.isOp() || player.hasPermission("hikabrain.admin.bypass")) return;
+        if (protectionService.isProtected(e.getBlock().getLocation())) {
+            e.setCancelled(true);
         }
     }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: HikaBrain
 main: com.example.hikabrain.HikaBrainPlugin
-version: 1.4.0
+version: 1.4.1
 api-version: "1.21"
 description: Hikabrain minigame for Spigot/Paper 1.21
 


### PR DESCRIPTION
## Summary
- ensure selection tool only triggers on main hand to avoid double "Position 2" message
- cancel block damage events inside protected zones so players can't crack blocks
- bump version to 1.4.1 and update docs

## Testing
- `gradle test`


------
https://chatgpt.com/codex/tasks/task_e_689db95aed9883249757cc0e810ced2e